### PR TITLE
Add proper support for `parabar` and `foreach` via `doParabar` package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
-.Rproj.user
-.Rhistory
-.RData
-.Ruserdata
+*.Rproj.user
+*.Rhistory
+*.RData
+*.Ruserdata
+*.Rcheck
+**/*.DS_Store
+**/*.cache
+**/*.temp
+**/*.tar.gz
+**/temp*.*
+.vscode
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,8 +11,8 @@ BugReports: https://github.com/anieBee/ClusterVAR/issues
 Encoding: UTF-8
 LazyData: true
 License: GPL-2
-Imports: stats, utils, graphics, grDevices, fastDummies, MASS, mvtnorm, scales, foreach, parallel, doParallel, parabar, iterators
-Suggests: 
+Imports: stats, utils, graphics, grDevices, fastDummies, MASS, mvtnorm, scales, foreach, parallel, doParallel, parabar, doParabar
+Suggests:
     knitr,
     rmarkdown,
     testthat (>= 3.0.0)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -16,7 +16,7 @@ import(doParallel) # for foreach()
 # import(doSNOW) # for foreach(); we use this to make the progress bar work in foreach
 
 import(parabar) # for progress bar (package by Mihai)
-import(iterators) # Also for Mihai's progress bar solution
+import(doParabar) # for `parabar` compatibility with `foreach` (package by Mihai)
 
 # Export
 export(LCVAR)
@@ -31,4 +31,3 @@ S3method(print, PredictableObs)
 S3method(summary, ClusterVAR)
 S3method(coef, ClusterVAR)
 S3method(plot, ClusterVAR)
-

--- a/R/callEMFuncsPARALLELIZED.R
+++ b/R/callEMFuncsPARALLELIZED.R
@@ -73,20 +73,38 @@ callEMFuncs <- function(Clusters,
 
   # ---- End: Code by Mihai ----
 
+  # Packages to export.
+  packages <- c("MASS", "mvtnorm", "fastDummies")
+
+  # Objects to export.
+  exports <- c(
+      "createOutputList", "callCalculateCoefficientsForRandoAndRational",
+      "calculateCoefficientsForRandoAndRational", "EMInit",
+      "EMFunc", "InitRat", "constraintsOnB", "checkComponentsCollapsed",
+      "InitPseudoRand", "calculateBandWZero", "reorderLags", "calculateA",
+      "determineLagOrder", "calculateU", "calculateW", "calculateRatio",
+      "calculateTau", "calculatePosterior", "calculateFYZ", "calculateB",
+      "calculateSigma", "checkSingularitySigma", "checkLikelihoodsNA",
+      "checkConvergence", "checkOutliers", "checkPosteriorsNA",
+      "calculateNPara", "calculateIC", "calculateBIC", "calculateICL",
+
+      # The following imports were missing, please double check them.
+      # Also, please see https://parabar.mihaiconstantin.com/articles/foreach
+      # for how `doParabar` handles the imports.
+      "RndSeed", "l_LagsPerCluster", "Rand", "Rational", "Initialization",
+      "PreviousSol", "HighestLag", "LowestLag", "Covariates", "nDepVar",
+      "qqq", "N", "PersEnd", "X", "PersStart", "Y", "LaggedPredictObs",
+      "NewPredictableObs", "it", "smallestClN", "PersEndU_NPred",
+      "PredictableObsConc", "LaggedPredictObsConc", "Tni_NPred",
+      "PersStartU_NPred", "SigmaIncrease", "Conv", "IDNames"
+  )
+
 
   # --- Start Foreach ---
   All_Solutions <- invisible(foreach::foreach(K = Clusters,
                                      # .options.snow = opts,
-                                     .packages = c("MASS", "mvtnorm", "fastDummies"),
-                                     .export = c("createOutputList", "callCalculateCoefficientsForRandoAndRational",
-                                                 "calculateCoefficientsForRandoAndRational", "EMInit",
-                                                 "EMFunc", "InitRat", "constraintsOnB", "checkComponentsCollapsed",
-                                                 "InitPseudoRand", "calculateBandWZero", "reorderLags", "calculateA",
-                                                 "determineLagOrder", "calculateU", "calculateW", "calculateRatio",
-                                                 "calculateTau", "calculatePosterior", "calculateFYZ", "calculateB",
-                                                 "calculateSigma", "checkSingularitySigma", "checkLikelihoodsNA",
-                                                 "checkConvergence", "checkOutliers", "checkPosteriorsNA",
-                                                 "calculateNPara", "calculateIC", "calculateBIC", "calculateICL")) %dopar%
+                                     .packages = packages,
+                                     .export = exports) %dopar%
                                {
 
                                  # Update progress bar

--- a/R/callEMFuncsPARALLELIZED.R
+++ b/R/callEMFuncsPARALLELIZED.R
@@ -106,7 +106,6 @@ callEMFuncs <- function(Clusters,
 
   # Show progress bar?
   parabar::set_option("progress_track", pbar)
-  #parabar::set_option("cores_minimum", 1)
 
   backend <- parabar::start_backend(cores = n_cores, cluster_type = "psock", backend_type = "async")
 

--- a/R/callEMFuncsPARALLELIZED.R
+++ b/R/callEMFuncsPARALLELIZED.R
@@ -65,11 +65,13 @@ callEMFuncs <- function(Clusters,
   doParabar::registerDoParabar(backend)
 
   # Configure type of progress bar (as before)
-  configure_bar(type = "basic",
-                max = length(Clusters),
-                initial = min(Clusters),
-                char = "=", style = 3)
-
+  parabar::configure_bar(
+      type = "basic",
+      max = length(Clusters),
+      initial = min(Clusters),
+      char = "=",
+      style = 3
+  )
 
   # ---- End: Code by Mihai ----
 
@@ -267,11 +269,3 @@ callEMFuncs <- function(Clusters,
   return(outlist)
 
 }  # eoF
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This is to replace the previous integration of `parabar` and `foreach` with a more robust solution provided by the [`doParabar`](https://parabar.mihaiconstantin.com/articles/foreach) package.

The previous code in [`callEMFuncsPARALLELIZED.R`](https://github.com/AnieBee/ClusterVAR/blob/bf9f44c87ed26b096691be922f423437f8410d56/R/callEMFuncsPARALLELIZED.R#L59-L90) implementing the `%dopar%` operator from the `foreach` package had several limitations (e.g., no error handling on the task and no implementation for other `foreach::foreach` arguments) and unintended side effects (i.e., it would automatically export *everything* in the calling environment). These issues have been addressed in the [`doParabar`](https://parabar.mihaiconstantin.com/articles/foreach) package, which also removes the need to pollute your estimation function with unnecessary code.

One thing that you can perhaps double-check yourselves is the cluster `.export` objects. In the previous code, everything would get exported, which can lead to unintended effects and hard-to-debug scenarios. In the vignette for `doParabar` you can find the following mention:

> *Note.* The `doParabar` package does not automatically export objects (i.e., or packages for that matter) to the backend. While this breaks "tradition" with other `foreach` adapter packages, it is a deliberate design choice made to encourage users to keep their scripts tidy and be mindful of what they export to the backend. (i.e., see the `.export`, `.noexport`, and `.packages` arguments of the `foreach` function).

You can, of course, still export everything in the respective environment if you really want to using `.export = ls(envir = environment())` and selectively remove what not to exclude via `.noexport = c("something")`, as shown below:

```r
# ...

foreach::foreach(
    # Collection.
    K = Clusters,

    # Export everything in the calling environment.
    .export = ls(envir = environment()),

    # Exclude something specific.
    .noexport = c("something")
) %dopar% {
    # Your computation.
    # ...
}

# ...
```

Finally, I think the `parallel` and `doParallel` can be safely removed, but I didn't do that in case you plan to use them somewhere else in your package.

I hope this helps! Cool package!